### PR TITLE
fix: while building link to libosi && tagging panda release

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "plugins/dependencies/panda/panda-wrapper"]
 	path = plugins/dependencies/panda/panda-wrapper
 	url = https://github.com/panda-re/panda
+	branch = v1.8.54
 [submodule "plugins/dependencies/libosi"]
 	path = plugins/dependencies/libosi
 	url = https://github.com/panda-re/libosi

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PANDA plugins
 
-This repo is a prototype that builds PANDA's plugins out of tree. This assumed that you have `libosi` already installed system wide. (Check out and build them [here](https://github.com/panda-re/libosi/tree/master))
+This repo is a prototype that builds PANDA's plugins out of tree. (Depends on [libosi](https://github.com/panda-re/libosi/tree/master))
 
 ## Download and Build
 ```bash

--- a/plugins/dependencies/CMakeExternal.cmake
+++ b/plugins/dependencies/CMakeExternal.cmake
@@ -10,35 +10,6 @@ if(NOT EXISTS "${LIBOSI_SRC_DIR}")
     message(FATAL_ERROR "Could not find LIBOSI_SRC_DIR: ${LIBOSI_SRC_DIR}")
 endif()
 
-#############################
-# Build the PANDA hypervisor
-#############################
-ExternalProject_Add(panda-ext
-    SOURCE_DIR "${PANDA_SRC_DIR}"
-    BINARY_DIR "${CMAKE_BINARY_DIR}/plugins-panda-build"
-    INSTALL_DIR "${CMAKE_INSTALL_PREFIX}"
-    INSTALL_COMMAND ""
-    CMAKE_ARGS
-        -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-        -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
-        -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
-        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-        ${USE_PROJECT_CMAKE_MODULE_PATH}
-    BUILD_BYPRODUCTS "${CMAKE_INSTALL_PREFIX}/lib/libpanda-i386.so" "${CMAKE_INSTALL_PREFIX}/lib/libpanda-x86_64.so"
-    )
-
-add_library(panda-i386 SHARED IMPORTED)
-add_dependencies(panda-i386 panda-ext)
-set_target_properties(panda-i386 PROPERTIES IMPORTED_LOCATION ${CMAKE_INSTALL_PREFIX}/lib/libpanda-i386.so)
-set_target_properties(panda-i386 PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
-    ${PANDA_SRC_DIR}/panda-wrapper/panda/include)
-
-add_library(panda-x86_64 SHARED IMPORTED)
-add_dependencies(panda-x86_64 panda-ext)
-set_target_properties(panda-x86_64 PROPERTIES IMPORTED_LOCATION ${CMAKE_INSTALL_PREFIX}/lib/libpanda-x86_64.so)
-set_target_properties(panda-x86_64 PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
-    ${PANDA_SRC_DIR}/panda-wrapper/panda/include)
-
 ####################################
 # Build the introspection libraries
 ####################################
@@ -58,19 +29,61 @@ ExternalProject_Add(libosi-ext
     BUILD_BYPRODUCTS "${CMAKE_INSTALL_PREFIX}/lib/libosi.so" "${CMAKE_INSTALL_PREFIX}/lib/libiohal.so" "${CMAKE_INSTALL_PREFIX}/lib/liboffset.so" 
 )
 
+set(LIBRARIES "-L${CMAKE_INSTALL_PREFIX}/lib")
+
 add_library(libiohal SHARED IMPORTED)
 add_dependencies(libiohal libosi-ext)
 set_target_properties(libiohal PROPERTIES IMPORTED_LOCATION ${CMAKE_INSTALL_PREFIX}/lib/libiohal.so)
 set_target_properties(libiohal PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${LIBOSI_SRC_DIR}/include)
+set(LIBRARIES "${LIBRARIES} -liohal")
 
 add_library(liboffset SHARED IMPORTED)
 add_dependencies(liboffset libosi-ext)
 set_target_properties(liboffset PROPERTIES IMPORTED_LOCATION ${CMAKE_INSTALL_PREFIX}/lib/liboffset.so)
 set_target_properties(liboffset PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${LIBOSI_SRC_DIR}/include)
+set(LIBRARIES "${LIBRARIES} -loffset")
 
 add_library(libosi SHARED IMPORTED)
 add_dependencies(libosi libosi-ext)
 set_target_properties(libosi PROPERTIES IMPORTED_LOCATION ${CMAKE_INSTALL_PREFIX}/lib/libosi.so)
 set_target_properties(libosi PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${LIBOSI_SRC_DIR}/include)
+set(LIBRARIES "${LIBRARIES} -losi")
+
+message("Root build directory: ${CMAKE_BINARY_DIR}")
+
+#############################
+# Build the PANDA hypervisor
+#############################
+ExternalProject_Add(panda-ext
+    SOURCE_DIR "${PANDA_SRC_DIR}"
+    BINARY_DIR "${CMAKE_BINARY_DIR}/plugins-panda-build"
+    INSTALL_DIR "${CMAKE_INSTALL_PREFIX}"
+    INSTALL_COMMAND ""
+    CMAKE_ARGS
+        -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+        -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
+        -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+	-DINCLUDE_DIR=${CMAKE_INSTALL_PREFIX}/include
+	-DLIBRARIES=${LIBRARIES}
+        ${USE_PROJECT_CMAKE_MODULE_PATH}
+    BUILD_BYPRODUCTS "${CMAKE_INSTALL_PREFIX}/lib/libpanda-i386.so" "${CMAKE_INSTALL_PREFIX}/lib/libpanda-x86_64.so"
+    )
+
+add_dependencies(panda-ext libosi-ext)
+
+add_library(panda-i386 SHARED IMPORTED)
+add_dependencies(panda-i386 panda-ext)
+#target_link_libraries(panda-i386 INTERFACE libosi liboffset libiohal)
+set_target_properties(panda-i386 PROPERTIES IMPORTED_LOCATION ${CMAKE_INSTALL_PREFIX}/lib/libpanda-i386.so)
+set_target_properties(panda-i386 PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+    ${PANDA_SRC_DIR}/panda-wrapper/panda/include)
+
+add_library(panda-x86_64 SHARED IMPORTED)
+add_dependencies(panda-x86_64 panda-ext)
+#target_link_libraries(panda-x86_64 INTERFACE libosi liboffset libiohal)
+set_target_properties(panda-x86_64 PROPERTIES IMPORTED_LOCATION ${CMAKE_INSTALL_PREFIX}/lib/libpanda-x86_64.so)
+set_target_properties(panda-x86_64 PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+    ${PANDA_SRC_DIR}/panda-wrapper/panda/include)
 
 set(CMAKE_INSTALL_RPATH "$ORIGIN/../lib")

--- a/plugins/dependencies/panda/CMakeLists.txt
+++ b/plugins/dependencies/panda/CMakeLists.txt
@@ -18,15 +18,26 @@ if (NOT NCPU EQUAL 0)
     set(EP_BUILD_ACCEL_FLAG -j${NCPU})
 endif()
 
+if (DEFINED INCLUDE_DIR)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I${INCLUDE_DIR}")
+endif()
+
+if (DEFINED LIBRARIES)
+    set(CMAKE_LD_FLAGS "${CMAKE_LD_FLAGS} ${LIBRARIES}")
+endif()
 
 include(ExternalProject)
-ExternalProject_Add(panda-ext
+ExternalProject_Add(panda-wrapped-ext
     SOURCE_DIR        "${PROJECT_SOURCE_DIR}/panda-wrapper"
     BINARY_DIR        "${CMAKE_BINARY_DIR}/panda-internal-build"
     INSTALL_DIR       "${CMAKE_INSTALL_PREFIX}"
-###CONFIGURE_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/panda-wrapper/configure --target-list=x86_64-softmmu,i386-softmmu --prefix=${CMAKE_INSTALL_PREFIX}
-    CONFIGURE_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/panda-wrapper/configure --target-list=x86_64-softmmu,i386-softmmu,arm-softmmu,aarch64-softmmu,ppc-softmmu,mips-softmmu,mipsel-softmmu --enable-llvm --with-llvm=/usr/lib/llvm-11 --prefix=${CMAKE_INSTALL_PREFIX}
-    
+    CONFIGURE_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/panda-wrapper/configure
+    ARGS
+        --target-list=x86_64-softmmu,i386-softmmu,arm-softmmu,aarch64-softmmu,ppc-softmmu,mips-softmmu,mipsel-softmmu
+        --enable-llvm
+        --with-llvm=/usr/lib/llvm-11
+        --prefix=${CMAKE_INSTALL_PREFIX}
+        --extra-cxxflags=${CMAKE_CXX_FLAGS}
+        --extra-ldflags=${CMAKE_LD_FLAGS}
     BUILD_COMMAND make ${EP_BUILD_ACCEL_FLAG}
 )
-


### PR DESCRIPTION
libosi being a submodule was previously not used to link against targets, this fixes that and removes the need to install libosi prior to install given that it will part of the install package; simplifying a few steps. 